### PR TITLE
ci: generate and publish install.sh via binstaller on release

### DIFF
--- a/.config/binstaller.yml
+++ b/.config/binstaller.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/binary-install/binstaller/main/schema/InstallSpec.json
+schema: v1
+name: tesh
+repo: feloy/tesh
+asset:
+    template: ${NAME}_${OS}_${ARCH}${EXT}
+    default_extension: .tar.gz
+    rules:
+        - when:
+            arch: amd64
+          arch: x86_64
+        - when:
+            arch: "386"
+          arch: i386
+        - when:
+            os: windows
+          ext: .zip
+    naming_convention:
+        os: titlecase
+        arch: lowercase
+supported_platforms:
+    - os: darwin
+      arch: amd64
+    - os: darwin
+      arch: arm64
+    - os: linux
+      arch: "386"
+    - os: linux
+      arch: amd64
+    - os: linux
+      arch: arm64
+    - os: windows
+      arch: "386"
+    - os: windows
+      arch: amd64
+    - os: windows
+      arch: arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,12 @@ jobs:
         with:
           go-version: 1.24
 
+      - name: Install binst
+        run: go install github.com/binary-install/binstaller/cmd/binst@v0.12.0
+
+      - name: Generate install.sh
+        run: binst gen --config=.config/binstaller.yml -o install.sh
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,8 @@ checksum:
   disable: true
 
 release:
+  extra_files:
+    - glob: ./install.sh
   footer: >-
 
     ---


### PR DESCRIPTION
Add a binstaller config (.config/binstaller.yml) that describes the tesh release asset naming convention. During the release workflow, install binst and run `binst gen` to produce an install.sh, which goreleaser then uploads as an extra release asset.
